### PR TITLE
Implement enemy bullets with linear speed

### DIFF
--- a/internal/assets/loader.go
+++ b/internal/assets/loader.go
@@ -132,6 +132,7 @@ const (
 	PlayButtonPath      = "images/startScene/play_button.png"
 	GameBackgroundPath  = "images/gameScene/Background/background.png"
 	PlayerBulletPath    = "images/gameScene/Bullets/PlayerBullets/PlayerBullet_Single.png"
+	EnemyBulletPath     = "images/gameScene/Bullets/EnemyBullets/EnemyBullet_Single.png"
 )
 
 // Preloaded assets that are used frequently throughout the game.
@@ -146,6 +147,7 @@ var (
 	PlayerSprite = LoadImage(PlayerSpritePath) // The player's ship sprite
 	PlayButton   = LoadImage(PlayButtonPath)   // The play button on the start screen
 	PlayerBullet = LoadImage(PlayerBulletPath) // The player's bullet sprite
+	EnemyBullet  = LoadImage(EnemyBulletPath)  // The enemy's bullet sprite
 )
 
 // GetStartBackground returns the start background image, loading it if necessary.

--- a/internal/core/gameplay/enemies/types.go
+++ b/internal/core/gameplay/enemies/types.go
@@ -28,11 +28,12 @@ import (
 // and updating enemy state, while specific behaviors would be implemented
 // in the AI system.
 type Enemy struct {
-	Type      string        // Type of enemy (e.g., "Pilz", "Kristall", etc.)
-	Position  math.Vector   // Position in world coordinates relative to center
-	Rotation  float64       // Rotation angle in degrees (0-360)
-	Image     *ebiten.Image // Cached enemy sprite for rendering
-	ImagePath string        // Path to the enemy image in the assets system
+	Type              string        // Type of enemy (e.g., "Pilz", "Kristall", etc.)
+	Position          math.Vector   // Position in world coordinates relative to center
+	Rotation          float64       // Rotation angle in degrees (0-360)
+	Image             *ebiten.Image // Cached enemy sprite for rendering
+	ImagePath         string        // Path to the enemy image in the assets system
+	TimeSinceLastShot float64       // Time elapsed since the enemy last fired
 }
 
 // NewEnemy creates a new enemy with the specified parameters.
@@ -51,10 +52,11 @@ type Enemy struct {
 // the caller is responsible for storing and managing the returned enemy.
 func NewEnemy(enemyType string, x, y float64, rotation float64, imagePath string) *Enemy {
 	return &Enemy{
-		Type:      enemyType,
-		Position:  math.Vector{X: x, Y: y},
-		Rotation:  rotation,
-		ImagePath: imagePath,
+		Type:              enemyType,
+		Position:          math.Vector{X: x, Y: y},
+		Rotation:          rotation,
+		ImagePath:         imagePath,
+		TimeSinceLastShot: 0,
 	}
 }
 
@@ -65,9 +67,9 @@ func NewEnemy(enemyType string, x, y float64, rotation float64, imagePath string
 // 3. Any state changes or animations (in future implementations)
 //
 // The current implementation is intentionally simple:
-// - The image is loaded on first update if not already loaded
-// - A high velocity value is passed to ApplyGravity to prevent movement
-//   (since the physics system ignores gravity for high-velocity objects)
+//   - The image is loaded on first update if not already loaded
+//   - A high velocity value is passed to ApplyGravity to prevent movement
+//     (since the physics system ignores gravity for high-velocity objects)
 //
 // This method returns an error if the update fails, which can be used
 // to signal that the enemy should be removed or that the game should
@@ -108,9 +110,10 @@ func (e *Enemy) Update() error {
 // 4. Apply rotation based on the enemy's orientation
 // 5. Scale the sprite to the appropriate size
 // 6. Calculate the final screen position considering:
-//    - World center
-//    - Enemy's position relative to center
-//    - Camera offset for scrolling
+//   - World center
+//   - Enemy's position relative to center
+//   - Camera offset for scrolling
+//
 // 7. Apply the final position transformation
 // 8. Render the sprite to the screen
 func (e *Enemy) Draw(screen *ebiten.Image, offsetX, offsetY float64, worldWidth, worldHeight int) {

--- a/internal/scenes/gameScene.go
+++ b/internal/scenes/gameScene.go
@@ -89,6 +89,7 @@ func (s *GameScene) Update(state *State) error {
 	}
 
 	s.handleShooting(state)
+	s.handleEnemyShooting(state)
 	var activeBullets []*projectiles.Bullet
 	for _, b := range s.bullets {
 		if !b.Update(state.DeltaTime) {
@@ -212,6 +213,8 @@ func (s *GameScene) Draw(screen *ebiten.Image, state *State) {
 }
 
 const fireInterval = 0.25
+const enemyFireInterval = 0.5
+const enemyShootRadius = 150.0
 
 // handleShooting manages bullet firing based on keyboard or touch input
 func (s *GameScene) handleShooting(state *State) {
@@ -239,9 +242,28 @@ func (s *GameScene) handleShooting(state *State) {
 	}
 }
 
+// handleEnemyShooting makes enemies fire bullets at the player when in range
+func (s *GameScene) handleEnemyShooting(state *State) {
+	playerPos := s.player.GetPosition()
+	for _, enemy := range s.enemies {
+		dx := playerPos.X - enemy.Position.X
+		dy := playerPos.Y - enemy.Position.Y
+		if dx*dx+dy*dy <= enemyShootRadius*enemyShootRadius {
+			enemy.TimeSinceLastShot += state.DeltaTime
+			if enemy.TimeSinceLastShot >= enemyFireInterval {
+				rot := stdmath.Atan2(dx, -dy)
+				s.bullets = append(s.bullets, projectiles.NewBullet(enemy.Position, rot, assets.EnemyBullet, 1.0))
+				enemy.TimeSinceLastShot = 0
+			}
+		} else if enemy.TimeSinceLastShot > enemyFireInterval {
+			enemy.TimeSinceLastShot = enemyFireInterval
+		}
+	}
+}
+
 // spawnBullet creates a new bullet at the player's position with the player's rotation
 func (s *GameScene) spawnBullet() {
 	pos := s.player.GetPosition()
 	rot := s.player.GetRotation()
-	s.bullets = append(s.bullets, projectiles.NewBullet(pos, rot))
+	s.bullets = append(s.bullets, projectiles.NewBullet(pos, rot, assets.PlayerBullet, projectiles.BulletAcceleration()))
 }


### PR DESCRIPTION
## Summary
- add BulletAcceleration helper and acceleration field on Bullet
- provide acceleration parameter when spawning bullets
- keep enemy bullets at constant speed using acceleration of 1.0

## Testing
- `go test ./...` *(fails: missing X11 headers for ebiten build)*

------
https://chatgpt.com/codex/tasks/task_b_6867865a112c83229af9a02fd09ab613